### PR TITLE
Pop over

### DIFF
--- a/build/_includes/pop-over/pop-over-component.html
+++ b/build/_includes/pop-over/pop-over-component.html
@@ -1,0 +1,8 @@
+<link rel="stylesheet" href="/assets/pop-over.css">
+
+<button popovertarget="my-popover" class="pop-over-button">Click for confetti</button>
+
+<div id="my-popover" popover>
+    <p>Thanks!</p>
+    <p>Hit <kbd>esc</kbd> or click away to close me</p>
+</div>

--- a/build/assets/pop-over.css
+++ b/build/assets/pop-over.css
@@ -1,0 +1,7 @@
+.pop-over-button{
+background-color: red;
+}
+
+#my-popover{
+    background-color: blue;
+}

--- a/src/_includes/pop-over/pop-over-component.html
+++ b/src/_includes/pop-over/pop-over-component.html
@@ -1,0 +1,8 @@
+<link rel="stylesheet" href="/assets/pop-over.css">
+
+<button popovertarget="my-popover" class="pop-over-button">Click for confetti</button>
+
+<div id="my-popover" popover>
+    <p>Thanks!</p>
+    <p>Hit <kbd>esc</kbd> or click away to close me</p>
+</div>

--- a/src/assets/pop-over.css
+++ b/src/assets/pop-over.css
@@ -1,0 +1,7 @@
+.pop-over-button{
+background-color: red;
+}
+
+#my-popover{
+    background-color: blue;
+}

--- a/src/index.html
+++ b/src/index.html
@@ -5,7 +5,6 @@ layout: layout.html
 <!-- Doormiddel van weather spreek je de elementen uit de api aan. -->
 <h1>Weather in {{ weather.latitude }}/{{ weather.longitude }}</h1>
 
-
 <p>Temperature: {{ weather.currentConditions.temp }}°C</p>
 <p>Conditions: {{ weather.currentConditions.conditions }}</p>
 <p>Humidity: {{ weather.currentConditions.humidity }}%</p>
@@ -14,9 +13,9 @@ layout: layout.html
 <h2>Forecast for the next few days:</h2>
 <ul>
   {% for day in weather.days %}
-    <li>
-      {{ day.datetime }}: {{ day.temp }}°C, {{ day.conditions }}
-    </li>
+  <li>
+    {{ day.datetime }}: {{ day.temp }}°C, {{ day.conditions }}
+  </li>
   {% endfor %}
 </ul>
 
@@ -27,3 +26,5 @@ layout: layout.html
 {% endfor %}
 
 <h3 class="typo1"> Typografie test </h3>
+
+{% include "pop-over/pop-over-component.html" %}


### PR DESCRIPTION
closes #9 

Je kunt tegenwoordig een pop-over gebruiken zonder javascript. Ik heb dit uitgeprobeerd. 

pop-over component doet het niet, waarom? 

Eerste probleem. 
Ik gebruikte `{% include "pop-over-component.html" %}` om de pop over html in de index.html aan te spreken. 
Dit werkt niet als de html file in een ander map staat. 
Uiteindelijk is dit de goede manier: ` {% include "pop-over/pop-over-component.html" %}` 

Tweede probleem zie image hier onder. 

<img width="269" alt="Image" src="https://github.com/user-attachments/assets/e969f7dc-2919-4e87-af7c-5e1dbbe53810" />

De pop over map moet in _includes staan. Anders kan 11ty het niet lezen. 

Nu doet de css het niet, waarom?
css moet in assets staan (anders kan 11ty de map niet vinden) en op deze manier worden aangesproken in de html file. 
` <link rel="stylesheet" href="/assets/pop-over.css"> `


Uiteindelijk is dit het geworden:

https://github.com/user-attachments/assets/7bf1fb87-0010-4193-8dbc-68a134676fb6

Ik heb niet gelet op de styling en ben alleen bezig geweest met de werking. 

